### PR TITLE
Make output more intuitive in litabot pagerduty output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem "tzinfo"
+gem "tzinfo", '~> 1.2.3'
 gemspec

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -14,4 +14,5 @@ module Exceptions
   class NoUser < StandardError; end
   class PeriodNotProvided < StandardError; end
   class NoTimeZone < StandardError; end
+  class UnknownUnit < StandardError; end
 end

--- a/lib/lita/commands/base_lookup.rb
+++ b/lib/lita/commands/base_lookup.rb
@@ -38,8 +38,9 @@ module Commands
     def base_layer
       id = schedule[:id]
       time_zone = schedule[:time_zone]
+      time_range = PDTime.only_now(time_zone)
 
-      @base_layer ||= pagerduty.get_base_layer(id, time_zone)
+      @base_layer ||= pagerduty.get_user_from_layer(id, time_range)
     end
 
     def user

--- a/lib/lita/commands/base_lookup_period.rb
+++ b/lib/lita/commands/base_lookup_period.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Commands
+  class BaseLookupPeriod
+    include Base
+
+    def call
+      response message: 'base_lookup_period.response', params: success_params
+    rescue Exceptions::SchedulesEmptyList
+      response message: 'base_lookup_period.no_matching_schedule',
+               params: { schedule_name: schedule_name }
+    rescue Exceptions::NoOncallUser
+      response message: 'base_lookup_period.no_one_on_call',
+               params: { schedule_name: schedule_name }
+    end
+
+    private
+
+    def schedule
+      @schedule ||= pagerduty.get_schedules(query: schedule_name).first
+    end
+
+    def schedule_name
+      @schedule_name ||= message.match_data[1].strip
+    end
+
+    def unit
+      @unit ||= message.match_data[2].strip
+    end
+
+    def offset
+      if message.match_data[3].nil?
+        @offset ||= 0
+      else
+        @offset ||= message.match_data[3].strip.to_i
+      end
+    end
+
+    def success_params
+      {
+        name: users[:summary],
+        email: users[:email],
+        layer_name: users['layer_name'],
+        schedule_name: schedule[:name],
+        layer_entries: users['layer_entries'].join("\n"),
+        override_entries: users['override_entries'].join("\n")
+      }
+    end
+
+    def users
+      id = schedule[:id]
+      time_zone = schedule[:time_zone]
+
+      if unit == 'month'
+        time_range = PDTime.get_whole_month(time_zone, offset)
+      elsif unit == 'year'
+        time_range = PDTime.get_whole_year(time_zone, offset)
+      else
+        # TODO This doesn't work.
+#         rescue Exceptions::UnknownUnit
+#           response message: 'base_lookup_period.unknown_unit',
+#                   params: {unit: unit}
+        # It gives
+#         SyntaxError: /home/ksandom/files/work/elastic/tasks/litabot/lita-pagerduty2/lib/lita/commands/base_lookup_period.rb:59: syntax error, unexpected keyword_rescue
+#                 rescue Exceptions::UnknownUnit
+#                 ^~~~~~
+
+      end
+
+      @users ||= pagerduty.get_users_from_layers(id, time_range)
+    end
+  end
+end

--- a/lib/lita/handlers/commands.yml
+++ b/lib/lita/handlers/commands.yml
@@ -28,7 +28,11 @@
   method: on_call_lookup
 - pattern: ^pager\sbase$
   method: on_call_list
-- pattern: ^pager\sbase\s(.*)$
+- pattern: ^pager\sbase\s([^ ]+)\s([^ ]+)$
+  method: base_lookup_period
+- pattern: ^pager\sbase\s([^ ]+)\s([^ ]+)\s([^ ]+)$
+  method: base_lookup_period
+- pattern: ^pager\sbase\s([^ ]+)$
   method: base_lookup
 - pattern: ^pager\s+me\s+(.+?)\s+(\d+)m?$
   method: pager_me

--- a/lib/pdtime.rb
+++ b/lib/pdtime.rb
@@ -3,31 +3,134 @@
 require 'tzinfo'
 
 class PDTime
-  def self.get_offset_for_timezone(timezone)
-    if timezone.nil?
+  def self.get_offset_for_time_zone(time_zone)
+    if time_zone.nil?
       utc_offset = 0
+    elsif time_zone.is_a? Integer
+      utc_offset = time_zone
     else
-      timezone = ::TZInfo::Timezone.get(timezone)
-      current_period = timezone.current_period
+      time_zone = ::TZInfo::Timezone.get(time_zone)
+
+      current_period = time_zone.current_period
       utc_offset = current_period.utc_total_offset_rational.numerator
     end
 
     utc_offset
   end
 
-  def self.get_time_range(timezone)
-    utc_offset = get_offset_for_timezone(timezone)
+  def self.get_now_unformatted(time_zone)
+    utc_offset = get_offset_for_time_zone(time_zone)
 
     local = DateTime.now
-    now_begin_unformatted = local.new_offset(Rational(utc_offset, 24))
-    now_begin = now_begin_unformatted.strftime('%Y-%m-%dT%H:%M:00')
+    local.new_offset(Rational(utc_offset, 24))
+  end
 
-    now_end_unformatted = local.new_offset(Rational(utc_offset, 24))
-    now_end = now_end_unformatted.strftime('%Y-%m-%dT%H:%M:01')
+  def self.only_now(time_zone)
+    now_unformatted = get_now_unformatted(time_zone)
+
+    now_begin = now_unformatted.strftime('%Y-%m-%dT%H:%M:00')
+    now_end = now_unformatted.strftime('%Y-%m-%dT%H:%M:01')
 
     {
       'now_begin' => now_begin,
       'now_end' => now_end
     }
+  end
+
+  def self.get_time_offset_from_time(time)
+    timezone_string = time[-5..-4].to_i
+  end
+
+  def self.is_now?(start, end_time)
+    now_source = only_now(get_time_offset_from_time(start))
+    inow = time_string_to_integer(now_source['now_begin'])
+    istart = time_string_to_integer(start)
+    iend = time_string_to_integer(end_time)
+
+    inow >= istart && inow <= iend
+  end
+
+  def self.time_string_to_integer(time)
+    unless time.nil?
+      out = time.tr('-', '')[0..7].to_i
+    end
+
+    out
+  end
+
+  def self.get_last_day_of_month(month_number)
+    local = DateTime.now
+    now_unformatted = local.new_offset(Rational(0, 24))
+    year = now_unformatted.strftime('%Y').to_i
+
+    Date.civil(year, month_number, -1).strftime('%d').to_i
+  end
+
+  def self.get_year_and_month(now_unformatted, month_offset)
+    year = now_unformatted.strftime('%Y').to_i
+    month = now_unformatted.strftime('%m').to_i + month_offset
+
+    if month > 12
+      year += 1
+      month = 1
+    elsif month < 1
+      year -= 1
+      month = 12
+    end
+
+    {
+      'year' => year,
+      'month' => month
+    }
+  end
+
+  def self.get_whole_month(time_zone, month_offset)
+    now_unformatted = get_now_unformatted(time_zone)
+    year_and_month = get_year_and_month(now_unformatted, month_offset)
+    prefix = year_and_month['year'].to_s + '-' + year_and_month['month'].to_s
+
+    last_day = get_last_day_of_month(year_and_month['month']).to_s
+
+    {
+      'now_begin' => prefix + '-01T00:00:00',
+      'now_end' => prefix + '-' + last_day + 'T23:59:59'
+    }
+  end
+
+  def self.get_last_month(time_zone)
+    get_whole_month(time_zone, -1)
+  end
+
+  def self.get_this_month(time_zone)
+    get_whole_month(time_zone, 0)
+  end
+
+  def self.get_next_month(time_zone)
+    get_whole_month(time_zone, 1)
+  end
+
+  def self.get_whole_year(time_zone, year_offset)
+    now_unformatted = get_now_unformatted(time_zone)
+    year = now_unformatted.strftime('%Y').to_i
+
+    requested_year = year + year_offset
+
+    {
+      'now_begin' => requested_year.to_s + '-01-01T00:00:00',
+      'now_end' => requested_year.to_s + '-12-31T23:59:59'
+    }
+  end
+
+  def self.get_last_year(time_zone)
+    # I imagine this function is only useful a couple of times a year.
+    get_whole_year(time_zone, 0)
+  end
+
+  def self.get_this_year(time_zone)
+    get_whole_year(time_zone, 0)
+  end
+
+  def self.get_next_year(time_zone)
+    get_whole_year(time_zone, 0)
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -53,6 +53,9 @@ en:
           base_lookup:
             syntax: pager base <schedule>
             desc: Show who the base on call person is for the given schedule
+          base_lookup_period:
+            syntax: pager base <schedule> <unit> [<offset>]
+            desc: "Show who the base on call people are for the given schedule, over a given period. Unit=(month|year). Offset: 0=current, -1=last, 1=next etc."
           whos_on_call:
             syntax: who's on call?
             desc: Show everyone currently on call (not implemented yet)
@@ -93,6 +96,11 @@ en:
           response: "%{name} (%{email}) is on call in the base layer (%{layer_name}) of %{schedule_name}."
           no_matching_schedule: "No matching schedules found for '%{schedule_name}'"
           no_one_on_call: "No one is currently on call for %{schedule_name}"
+        base_lookup_period:
+          response: "People on call for (%{layer_name}) of %{schedule_name}:\n%{layer_entries}\n\nOverrides:\n%{override_entries}"
+          no_matching_schedule: "No matching schedules found for '%{schedule_name}'"
+          no_one_on_call: "No one is currently on call for %{schedule_name}"
+          unknown_unit: "I don't know the unit #{unit}. Expecting month or year."
         pager_me:
           success: "%{name} (%{email}) is now on call until %{finish}"
           failure: "failed to take the pager"

--- a/spec/lita/handlers/base_lookup_spec.rb
+++ b/spec/lita/handlers/base_lookup_spec.rb
@@ -14,7 +14,7 @@ describe Lita::Handlers::Pagerduty, lita_handler: true do
 
     it 'no one on call' do
       expect_any_instance_of(Pagerduty).to receive(:get_schedules).and_return([{ id: 'abc123', name: 'abc', time_zone: 'America/Los_Angeles' }])
-      expect_any_instance_of(Pagerduty).to receive(:get_base_layer).and_return({ 'now' => '2019-07-31T08:56:00', 'end' => '2019-07-31T08:56:01-07:00', 'layer_name' => 'Thingery', 'user' => { id: 'abc123' } })
+      expect_any_instance_of(Pagerduty).to receive(:get_user_from_layer).and_return({ 'now' => '2019-07-31T08:56:00', 'end' => '2019-07-31T08:56:01-07:00', 'layer_name' => 'Thingery', 'user' => { id: 'abc123' } })
       expect_any_instance_of(Pagerduty).to receive(:get_user).and_raise(Exceptions::NoOncallUser)
       send_command('pager base abc')
       expect(replies.last).to eq('No one is currently on call for abc')
@@ -22,7 +22,7 @@ describe Lita::Handlers::Pagerduty, lita_handler: true do
 
     it 'somebody on call' do
       expect_any_instance_of(Pagerduty).to receive(:get_schedules).and_return([{ id: 'abc123', name: 'abc', time_zone: 'America/Los_Angeles' }])
-      expect_any_instance_of(Pagerduty).to receive(:get_base_layer).and_return({ 'now' => '2019-07-31T08:56:00', 'end' => '2019-07-31T08:56:01-07:00', 'layer_name' => 'Thingery', 'user' => { id: 'abc123' } })
+      expect_any_instance_of(Pagerduty).to receive(:get_user_from_layer).and_return({ 'now' => '2019-07-31T08:56:00', 'end' => '2019-07-31T08:56:01-07:00', 'layer_name' => 'Thingery', 'user' => { id: 'abc123' } })
       expect_any_instance_of(Pagerduty).to receive(:get_user).and_return({summary: 'foo', email: 'foo@pagerduty.com'})
       send_command('pager base abc')
       expect(replies.last).to eq('foo (foo@pagerduty.com) is on call in the base layer (Thingery) of abc.')

--- a/spec/pdtime_spec.rb
+++ b/spec/pdtime_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe PDTime do
+  it 'get_last_day_of_month' do
+    expect(PDTime.get_last_day_of_month(10)).to eq(31)
+    expect(PDTime.get_last_day_of_month(11)).to eq(30)
+    expect(PDTime.get_last_day_of_month(12)).to eq(31)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ SimpleCov.formatters = [
 SimpleCov.start { add_filter '/spec/' }
 
 require 'lita-pagerduty'
+require 'pdtime'
 require 'lita/rspec'
 Lita.version_3_compatibility_mode = false
 


### PR DESCRIPTION
# Overview

Introduces the more intuitive layout for who's on-call at a given point in time. [Examples here](https://github.com/elastic/search-developer-productivity/issues/76).

# Test it

Clone [lita-the-bot](https://github.com/swiftype/lita-the-bot/).

You'll want to put a line like this [here](https://github.com/swiftype/lita-the-bot/blob/master/Gemfile#L6).
```ruby
gem 'lita-pagerduty', :git => 'git@github.com:swiftype/lita-pagerduty.git', :branch => 'ksandom/base-oncall-monthly'
```

Startup from the [lita-the-bot](https://github.com/swiftype/lita-the-bot/) directory.
```bash
bundle install;ADAPTER=shell bundle exec lita
```

Some commands
```
bot > pager base swiftype-sre
bot > pager base swiftype-sre month
bot > pager base swiftype-sre month 1
bot > pager base swiftype-sre month 2
bot > pager base swiftype-sre month -1
bot > pager base swiftype-sre year
bot > pager base swiftype-sre year 1
```

# Thoughts

When you see the output for a year, it becomes very apparent that this would not scale if a request was made for the user details of every line. Instead they are cached within the object for that run. A cool improvement would be to put this into redis with a TTL (eg 900 seconds).  This would cut out all of the user look ups for that TTL regardless of whether they are in the same litabot request.

The requests that are made to pagerduty are
* 1 request for the complete schedule in a time range.
* n requests for the users in that schedule, where n is the number of **unique** users.