### PR TITLE
Look up schedules by week

### DIFF
--- a/lib/pagerduty.rb
+++ b/lib/pagerduty.rb
@@ -97,6 +97,8 @@ class Pagerduty # rubocop:disable Metrics/ClassLength
     layers = schedule[:schedule_layers]
     base_layer = layers.last
 
+    raise Exceptions::SchedulesEmptyList if layers.empty?
+
     layer_users = get_users_from_layer(layers.last)
     formatted_layer_users = format_users(layer_users)
 

--- a/lib/pdtime.rb
+++ b/lib/pdtime.rb
@@ -133,4 +133,17 @@ class PDTime
   def self.get_next_year(time_zone)
     get_whole_year(time_zone, 0)
   end
+
+  def self.get_whole_week(time_zone, week_offset)
+    today = get_now_unformatted(time_zone)
+    days_since_sunday = 0 - today.wday # Sunday is wday 0
+    days_from_today_until_desired_sunday = days_since_sunday + (7 * week_offset)
+    desired_week_start = today + days_from_today_until_desired_sunday
+    desired_week_end = desired_week_start + 7
+
+    {
+      'now_begin' => desired_week_start.strftime('%Y-%m-%d') + 'T23:59:59',
+      'now_end' => desired_week_end.strftime('%Y-%m-%d') + 'T00:00:00'
+    }
+  end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -55,7 +55,7 @@ en:
             desc: Show who the base on call person is for the given schedule
           base_lookup_period:
             syntax: pager base <schedule> <unit> [<offset>]
-            desc: "Show who the base on call people are for the given schedule, over a given period. Unit=(month|year). Offset: 0=current, -1=last, 1=next etc."
+            desc: "Show who the base on call people are for the given schedule, over a given period. Unit=(week|month|year). Offset: 0=current, -1=last, 1=next etc."
           whos_on_call:
             syntax: who's on call?
             desc: Show everyone currently on call (not implemented yet)
@@ -100,7 +100,7 @@ en:
           response: "People on call for (%{layer_name}) of %{schedule_name}:\n%{layer_entries}\n\nOverrides:\n%{override_entries}"
           no_matching_schedule: "No matching schedules found for '%{schedule_name}'"
           no_one_on_call: "No one is currently on call for %{schedule_name}"
-          unknown_unit: "I don't know the unit #{unit}. Expecting month or year."
+          unknown_unit: "I don't know the unit '%{unit}'. Expecting week, month or year."
         pager_me:
           success: "%{name} (%{email}) is now on call until %{finish}"
           failure: "failed to take the pager"

--- a/spec/lita/handlers/base_lookup_period_spec.rb
+++ b/spec/lita/handlers/base_lookup_period_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Lita::Handlers::Pagerduty, lita_handler: true do
+  context 'base abc week' do
+    it do
+      is_expected.to route_command('pager base abc week').to(:base_lookup_period)
+    end
+
+    it 'schedule not found' do
+      expect_any_instance_of(Pagerduty).to receive(:get_schedules).and_raise(Exceptions::SchedulesEmptyList)
+      send_command('pager base abc week')
+      expect(replies.last).to eq('No matching schedules found for \'abc\'')
+    end
+
+    it 'period specified before schedule start date' do
+      expect_any_instance_of(Pagerduty).to receive(:get_schedules).and_return([{ id: 'abc123', name: 'abc', time_zone: 'America/Los_Angeles' }])
+      expect_any_instance_of(Pagerduty).to receive(:get_users_from_layers).and_raise(Exceptions::SchedulesEmptyList)
+      send_command('pager base abc week -50')
+      expect(replies.last).to eq('No matching schedules found for \'abc\'')
+    end
+
+    it 'somebody on call' do
+      expect_any_instance_of(Pagerduty).to receive(:get_schedules).and_return([{ id: 'abc123', name: 'abc', time_zone: 'America/Los_Angeles' }])
+      expect_any_instance_of(Pagerduty).to receive(:get_users_from_layers).and_return({"layer_name"=>"Layer 1", "layer_entries"=>["2020-11-22T23:59:59-05:00 - 2020-11-26T07:00:00-05:00  user1@elastic.co (User 1)", "2020-11-26T07:00:00-05:00 - 2020-11-29T00:00:00-05:00  user2@elastic.co (User 2)"], "override_entries"=>["None."]})
+      send_command('pager base abc week')
+      expect(replies.last).to eq("People on call for (Layer 1) of abc:\n"\
+        "2020-11-22T23:59:59-05:00 - 2020-11-26T07:00:00-05:00  user1@elastic.co (User 1)\n"\
+        "2020-11-26T07:00:00-05:00 - 2020-11-29T00:00:00-05:00  user2@elastic.co (User 2)\n"\
+        "\n"\
+        "Overrides:\n"\
+        "None.")
+    end
+
+    it 'invalid unit' do
+      expect_any_instance_of(Pagerduty).to receive(:get_schedules).and_return([{ id: 'abc123', name: 'abc', time_zone: 'America/Los_Angeles' }])
+      send_command('pager base abc fortnight')
+      expect(replies.last).to eq("I don't know the unit 'fortnight'. Expecting week, month or year.")
+    end
+  end
+end

--- a/spec/pdtime_spec.rb
+++ b/spec/pdtime_spec.rb
@@ -6,4 +6,28 @@ describe PDTime do
     expect(PDTime.get_last_day_of_month(11)).to eq(30)
     expect(PDTime.get_last_day_of_month(12)).to eq(31)
   end
+  it 'get_whole_week next week' do
+    allow(DateTime).to receive(:now).and_return DateTime.new(2020,11,11)
+    expect(PDTime.get_whole_week('America/New_York', 1)).to eq(
+      {
+        "now_begin"=>"2020-11-15T23:59:59",
+        "now_end"=>"2020-11-22T00:00:00"
+      })
+  end
+  it 'get_whole_week this week' do
+    allow(DateTime).to receive(:now).and_return DateTime.new(2020,11,11)
+    expect(PDTime.get_whole_week('America/New_York', 0)).to eq(
+      {
+        "now_begin"=>"2020-11-08T23:59:59",
+        "now_end"=>"2020-11-15T00:00:00"
+      })
+  end
+  it 'get_whole_week last week' do
+    allow(DateTime).to receive(:now).and_return DateTime.new(2020,11,11)
+    expect(PDTime.get_whole_week('America/New_York', -1)).to eq(
+      {
+        "now_begin"=>"2020-11-01T23:59:59",
+        "now_end"=>"2020-11-08T00:00:00"
+      })
+  end
 end


### PR DESCRIPTION
Add support to the `lita-pagerduty` bot to look up who is on call for a given week.

This allows one to ask, e.g. "Who's on-call for SDH next week?" by querying:
```
pager base schedule-sdh-enterprise-search week 1
```

Added some more spec coverage, too.